### PR TITLE
bug_4692

### DIFF
--- a/paypal/standard/ipn/models.py
+++ b/paypal/standard/ipn/models.py
@@ -18,7 +18,7 @@ class PayPalIPN(PayPalStandardBase):
         return urlopen(
             self.get_endpoint(),
             'cmd=_notify-validate&{}'.format(self.query).encode()
-        ).read()
+        ).read().decode()
 
     def _verify_postback(self):
         if self.response != "VERIFIED":


### PR DESCRIPTION
urlopen on py3 expects bytes and returns bytes, encode/decode as required.